### PR TITLE
chore: add CODEOWNERS file to automate PR reviews

### DIFF
--- a/.changeset/orange-falcons-hunt.md
+++ b/.changeset/orange-falcons-hunt.md
@@ -1,0 +1,5 @@
+---
+"@techtrain/terminal-design-tokens": patch
+---
+
+chore: add CODEOWNERS file to automate PR reviews

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @TechBowl-japan/design-system will be requested for
+# review when someone opens a pull request.
+*       @TechBowl-japan/design-system
+
+# Token definitions ownership
+/tokens/ @TechBowl-japan/design-system
+
+# Build configuration ownership
+*.json   @TechBowl-japan/design-system
+/config.json   @TechBowl-japan/design-system
+
+# Workflow and GitHub Actions
+/.github/workflows/   @TechBowl-japan/design-system

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @TechBowl-japan/design-system will be requested for
-# review when someone opens a pull request.
-*       @TechBowl-japan/design-system
-
-# Token definitions ownership
-/tokens/ @TechBowl-japan/design-system
-
-# Build configuration ownership
-*.json   @TechBowl-japan/design-system
-/config.json   @TechBowl-japan/design-system
-
-# Workflow and GitHub Actions
-/.github/workflows/   @TechBowl-japan/design-system
+*   @valbeat


### PR DESCRIPTION
## Summary
- Added CODEOWNERS file to automatically assign reviewers
- Designated @TechBowl-japan/design-system team as owners for all files
- Specified ownership for token definitions, build configurations, and workflows

## Test plan
- Verify that PRs automatically assign the correct reviewers
- Confirm that the design-system team is properly tagged when PRs are created

This helps streamline the review process and ensures that the right people are notified of relevant changes.