### PR TITLE
docs: add Figma links to README

### DIFF
--- a/.changeset/orange-bugs-admire.md
+++ b/.changeset/orange-bugs-admire.md
@@ -1,0 +1,7 @@
+---
+"@techtrain/terminal-design-tokens": patch
+---
+
+docs: add Figma links to README
+- Add direct link to Figma design system at the top of README
+- Add Design System section with more details about Figma source

--- a/.changeset/orange-bugs-admire.md
+++ b/.changeset/orange-bugs-admire.md
@@ -2,6 +2,5 @@
 "@techtrain/terminal-design-tokens": patch
 ---
 
-docs: add Figma links to README
+docs: add Figma link to README
 - Add direct link to Figma design system at the top of README
-- Add Design System section with more details about Figma source

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ npm i @techtrain/terminal-design-tokens
 import DesignToken from '@techtrain/terminal-design-tokens';
 ```
 
-## Design System
-
-Our design tokens are maintained in Figma and exported using the [Design Tokens](https://www.figma.com/community/plugin/888356646278934516/design-tokens) plugin.
-
-- [TechTrain Terminal Design System](https://www.figma.com/community/file/1472050808130527580/techtrain-terminal-design-system) - Explore our complete design system
-
 ## Contributing
 
 For information on how to contribute to this project, please see our [Contributing Guide](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Design tokens for TechTrain's design system "Terminal". This package uses [Style Dictionary](https://amzn.github.io/style-dictionary) to transform tokens defined in JSON into multiple platform outputs.
 
+🎨 [View in Figma](https://www.figma.com/community/file/1472050808130527580/techtrain-terminal-design-system) - Explore our design system in Figma
+
 ## Features
 
 - Consistent design tokens across platforms
@@ -24,6 +26,12 @@ npm i @techtrain/terminal-design-tokens
 ```typescript
 import DesignToken from '@techtrain/terminal-design-tokens';
 ```
+
+## Design System
+
+Our design tokens are maintained in Figma and exported using the [Design Tokens](https://www.figma.com/community/plugin/888356646278934516/design-tokens) plugin.
+
+- [TechTrain Terminal Design System](https://www.figma.com/community/file/1472050808130527580/techtrain-terminal-design-system) - Explore our complete design system
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Add direct link to Figma design system at the top of README
- Add Design System section with more information about the Figma source

## Benefits
- Provides immediate access to the Figma design system file
- Improves documentation for both developers and designers
- Makes clear the source of truth for the design tokens

## Test plan
- Verify links work correctly and point to the right Figma files
- Confirm the link text is clear and descriptive