### PR TITLE
chore: clean up design tokens by removing unused tokens and fixing typos

### DIFF
--- a/.changeset/cleanup-unused-tokens.md
+++ b/.changeset/cleanup-unused-tokens.md
@@ -1,0 +1,9 @@
+---
+"@techtrain/terminal-design-tokens": patch
+---
+
+Clean up design tokens by removing unused tokens and fixing typos
+
+- Remove unused "techtrain theme" tokens from primitive and semantic colors
+- Remove unused "spacing" tokens from primitive size
+- Fix typo: rename "blakepoint" to "breakpoint"

--- a/tokens/design-tokens.tokens.json
+++ b/tokens/design-tokens.tokens.json
@@ -1,17 +1,5 @@
 {
   "primitive color": {
-    "techtrain theme": {
-      "primary": {
-        "type": "color",
-        "value": "#3d3d5cff",
-        "blendMode": "normal"
-      },
-      "secondary": {
-        "type": "color",
-        "value": "#5aa6d9ff",
-        "blendMode": "normal"
-      }
-    },
     "techtrain blue": {
       "5": {
         "type": "color",
@@ -694,18 +682,6 @@
     }
   },
   "semantics color": {
-    "theme": {
-      "primary": {
-        "description": "TechTrainのメインカラー",
-        "type": "color",
-        "value": "{primitive color.techtrain theme.primary}"
-      },
-      "secondary": {
-        "description": "TechTrainのサブカラー",
-        "type": "color",
-        "value": "{primitive color.techtrain theme.secondary}"
-      }
-    },
     "background": {
       "primary": {
         "description": "基準となる背景色です。",
@@ -1024,32 +1000,6 @@
     }
   },
   "primitive size": {
-    "spacing": {
-      "xs": {
-        "type": "dimension",
-        "value": 4
-      },
-      "sm": {
-        "type": "dimension",
-        "value": 8
-      },
-      "md": {
-        "type": "dimension",
-        "value": 16
-      },
-      "lg": {
-        "type": "dimension",
-        "value": 24
-      },
-      "xl": {
-        "type": "dimension",
-        "value": 32
-      },
-      "2xl": {
-        "type": "dimension",
-        "value": 48
-      }
-    },
     "devicesize": {
       "pc-1920px": {
         "type": "dimension",
@@ -1317,7 +1267,7 @@
       }
     }
   },
-  "blakepoint": {
+  "breakpoint": {
     "window": {
       "device": {
         "type": "string",


### PR DESCRIPTION
## Summary
This PR cleans up the design tokens by removing unused tokens and fixing a typo:
- Remove unused "techtrain theme" tokens from primitive and semantic colors
- Remove unused "spacing" tokens from primitive size
- Fix typo: rename "blakepoint" to "breakpoint"

## Changes
- **Removed unused primitive color tokens**: `techtrain theme.primary` and `techtrain theme.secondary`
- **Removed unused semantic color tokens**: `theme.primary` and `theme.secondary` that referenced the removed primitive tokens
- **Removed unused spacing tokens**: Entire `spacing` section from `primitive size` containing xs, sm, md, lg, xl, 2xl values
- **Fixed typo**: Renamed `blakepoint` to `breakpoint` in the token structure

## Test plan
- [x] Verify build still passes with `npm run build`
- [x] Check that no existing tokens reference the removed tokens
- [x] Confirm the typo fix doesn't break any existing references