### PR TITLE
feat: add Dependabot configuration

### DIFF
--- a/.changeset/brave-dogs-dance.md
+++ b/.changeset/brave-dogs-dance.md
@@ -1,0 +1,5 @@
+---
+"@techtrain/terminal-design-tokens": patch
+---
+
+Add Dependabot configuration for automated dependency updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
     labels:
       - "dependencies"
       - "npm"
-    # Assignees for PRs
-    assignees:
-      - "TechBowl-japan"
     # Allow both direct and indirect updates for all packages
     allow:
       - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `package-lock.json` files in the root directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    # Limit number of open pull requests for version updates
+    open-pull-requests-limit: 5
+    # Raise pull requests for version updates only
+    versioning-strategy: increase
+    # Labels to apply to PRs
+    labels:
+      - "dependencies"
+      - "npm"
+    # Assignees for PRs
+    assignees:
+      - "TechBowl-japan"
+    # Allow both direct and indirect updates for all packages
+    allow:
+      - dependency-type: "all"
+    # Group dependency updates
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+        dependency-type: "development"
+      production-dependencies:
+        patterns:
+          - "*"
+        dependency-type: "production"


### PR DESCRIPTION
## Summary
- Dependabotを導入して依存関係の自動更新を設定
- 毎週月曜日に更新チェックを実行
- 開発用と本番用の依存関係をグループ化

## Configuration Details
- **更新頻度**: 毎週月曜日 9:00 JST
- **最大PR数**: 5つまで
- **グループ化**: development/production依存関係を分離
- **ラベル**: `dependencies`, `npm`を自動付与

## Test plan
- [ ] `.github/dependabot.yml`の構文が正しいことを確認
- [ ] マージ後、Dependabotが正常に動作することを確認