### PR TITLE
chore: sync package-lock.json with @changesets/cli optional peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
@@ -2916,6 +2928,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
## Summary
- Dependabot PRs #144-#148 were merged into main with a `Build` check failure
- Root cause: `npm ci` failed because `package-lock.json` was missing optional/peer transitive deps of `@changesets/cli`:
  - `@types/node@25.9.1`
  - `undici-types@7.24.6`
- This PR regenerates `package-lock.json` via `npm install` against `origin/main`, adding only those two entries (21 lines)

## Why was Build not enforced?
`Build` is not configured as a required status check on `main`, so auto-merge proceeded despite the failure. Worth revisiting branch protection separately.

## Test plan
- [ ] CI `Build` passes on this branch
- [ ] `npm ci` succeeds locally
- [ ] No production dependency changes (devDependencies transitive only)