### PR TITLE
fix: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
@@ -2916,6 +2928,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
## Summary
- `package-lock.json` がベースブランチで `package.json` と同期していなかったため、CI の `npm ci` が失敗していた
- これにより、Dependabot の patch PR 5件（#155, #156, #157, #158, #159）がすべてマージ不可になっていた
- `npm install` を実行して lock file を再生成

## Test plan
- [ ] CI (`npm ci` → build) が通ることを確認
- [ ] マージ後、Dependabot PR の CI が通るようになることを確認