### PR TITLE
fix: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
@@ -2916,6 +2928,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
## Summary
- `npm ci` was failing in the `Release` workflow on `main` (see run 28469443188 and subsequent Dependabot Updates runs) because `package-lock.json` was missing `@types/node@26.0.1` and `undici-types@8.3.0`, transitive peer deps of `@changesets/cli`.
- This likely happened because several Dependabot PRs (#162–#166) merged in quick succession without each rebasing/regenerating the lockfile against the latest `main`.
- Ran `npm install` to resync the lockfile, then verified `npm ci` and `npm run build` both succeed.

## Test plan
- [x] `rm -rf node_modules && npm ci` succeeds
- [x] `npm run build` succeeds