### PR TITLE
chore: require Node.js 24 (Active LTS)

### DIFF
--- a/.changeset/heavy-pandas-shake.md
+++ b/.changeset/heavy-pandas-shake.md
@@ -1,0 +1,5 @@
+---
+"@techtrain/terminal-design-tokens": minor
+---
+
+Require Node.js 24 (bump `engines.node` from 22.x to 24.x, the current Active LTS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "style-dictionary": "5.5.0"
       },
       "engines": {
-        "node": "22.x"
+        "node": "24.x"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "build": "style-dictionary build",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `22.x` to `24.x` (current Active LTS)
- CI workflows follow automatically via `node-version-file: 'package.json'`
- Verified `npm install` and `npm run build` (style-dictionary) succeed on Node v24.18.1

## Background
Node 22 entered Maintenance LTS (EOL: April 2027). All direct dependencies are already on their latest versions after the recent Dependabot merges (#173–#176, #169), so this engines bump is the last remaining update.

## Changeset
Included as `minor` since the published package's `engines` requirement changes for consumers.