### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,3 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Switch npm publishing from a long-lived `NPM_TOKEN` to **Trusted Publishing (OIDC)**.

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step
- `permissions.id-token: write` is already present, so no other workflow change is needed
- `GITHUB_TOKEN` stays (used by changesets/action to open the Version Packages PR)

## Background
The 0.3.0 publish failed with `E404 PUT /@techtrain%2fterminal-design-tokens` — npm returns 404 for unauthorized tokens, so the stored `NPM_TOKEN` has expired or lost publish rights. Trusted Publishing removes the token entirely and cannot expire.

Requirements are already met: Node 24 ships npm 11.16.0 (trusted publishing needs >= 11.5.1).

## ⚠️ Merge order
**Do not merge until the Trusted Publisher is registered on npmjs.com** (Organization: `TechBowl-japan`, Repository: `terminal-design-tokens`, Workflow: `release.yml`, Allowed action: `npm publish`).

Merging this before that registration would remove the only auth method and the publish would keep failing. Once registered, merging this PR pushes to main, which retriggers Release and publishes the pending 0.3.0.

## Follow-up
After a successful publish, the now-unused `NPM_TOKEN` repository secret can be deleted.